### PR TITLE
Update typescript and ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint-staged": "^11.0.0",
     "mocha": "^8.4.0",
     "rimraf": "^3.0.2",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.2.4"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
The current typescript/ts-node combination is not working. Out of the
box runinng the tests fails with

```
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
```

Updating both packages resolves the issue.

Change-type: minor